### PR TITLE
Fix issue #4

### DIFF
--- a/codegen/src/delegate.rs
+++ b/codegen/src/delegate.rs
@@ -59,8 +59,8 @@ impl portrait_framework::Generate for Generator {
                         .filter(|attr| attr.path().is_ident("cfg"))
                         .cloned()
                         .collect();
-                    let ref_ = if let Some((and, lifetime)) = &receiver.reference {
-                        Some(quote!(#and #lifetime))
+                    let ref_ = if let Some((and, _lifetime)) = &receiver.reference {
+                        Some(quote!(#and))
                     } else {
                         None
                     };

--- a/codegen/src/delegate.rs
+++ b/codegen/src/delegate.rs
@@ -85,7 +85,7 @@ impl portrait_framework::Generate for Generator {
                         .filter(|attr| attr.path().is_ident("cfg"))
                         .cloned()
                         .collect();
-                    if let syn::Pat::Ident(pat) = &*typed.pat {
+                    if let syn::Pat::Ident(pat) = &mut *typed.pat {
                         if pat.ident == "self" {
                             // Note: this syntax only works if delegate_expr returns exactly the receiver type.
                             let delegate_expr = &delegate_value
@@ -99,7 +99,11 @@ impl portrait_framework::Generate for Generator {
                                 })?
                                 .expr;
                             return Ok(quote! { #(#arg_attrs)* #delegate_expr });
+                        } else {
+                            // Suppress `mut` when passing arguments.
+                            pat.mutability = None;
                         }
+
                     }
 
                     let pat = &typed.pat;


### PR DESCRIPTION
* Fix delegation when a function argument is passed as reference with lifetime annotation
* Fix delegation when a function argument in a default implementation is specified as `mut`